### PR TITLE
Add Next.js backend routes

### DIFF
--- a/app/api/prompt/fetch-molecule-data/route.ts
+++ b/app/api/prompt/fetch-molecule-data/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchMoleculeData } from '../../../../lib/pubchem';
+
+export async function POST(req: NextRequest) {
+  const { query } = await req.json();
+  if (!query) {
+    return NextResponse.json({ error: 'Missing query' }, { status: 400 });
+  }
+  try {
+    const data = await fetchMoleculeData(query);
+    return NextResponse.json(data);
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/app/api/prompt/generate-from-pubchem/route.ts
+++ b/app/api/prompt/generate-from-pubchem/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchMoleculeData, moleculeHTML } from '../../../../lib/pubchem';
+import { isMolecularPrompt } from '../../../../lib/llm';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const query = body.prompt as string;
+  if (!query) {
+    return NextResponse.json({ error: 'Missing prompt', status: 'failed' }, { status: 400 });
+  }
+  const ok = await isMolecularPrompt(query);
+  if (!ok) {
+    return NextResponse.json({ status: 'failed', job_id: 'rejected', error: 'Prompt not about molecules' });
+  }
+  try {
+    const data = await fetchMoleculeData(query);
+    const html = moleculeHTML(data);
+    return NextResponse.json({ pdb_data: data.pdb_data, result_html: html, title: data.name });
+  } catch (err: any) {
+    return NextResponse.json({ status: 'failed', error: err.message }, { status: 500 });
+  }
+}

--- a/app/api/prompt/generate-molecule-diagram/route.ts
+++ b/app/api/prompt/generate-molecule-diagram/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { generateDiagram } from '../../../../lib/diagram';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  try {
+    const result = await generateDiagram(body);
+    return NextResponse.json(result);
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/app/api/prompt/generate-molecule-html/route.ts
+++ b/app/api/prompt/generate-molecule-html/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { moleculeHTML } from '../../../../lib/pubchem';
+
+export async function POST(req: NextRequest) {
+  const { molecule_data } = await req.json();
+  if (!molecule_data) {
+    return NextResponse.json({ error: 'Missing molecule data' }, { status: 400 });
+  }
+  const html = moleculeHTML(molecule_data);
+  return NextResponse.json({ html });
+}

--- a/app/api/prompt/models/route.ts
+++ b/app/api/prompt/models/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+import { listModels } from '../../../../lib/models';
+
+export async function GET() {
+  return NextResponse.json(listModels());
+}

--- a/app/api/prompt/process/[jobId]/route.ts
+++ b/app/api/prompt/process/[jobId]/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getJob } from '../../../../../lib/jobStore';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { jobId: string } }
+) {
+  const job = getJob(params.jobId);
+  if (!job) {
+    return NextResponse.json({ error: 'Job not found' }, { status: 404 });
+  }
+  return NextResponse.json(job);
+}

--- a/lib/diagram.ts
+++ b/lib/diagram.ts
@@ -1,0 +1,18 @@
+import { DiagramPromptRequest, DiagramResponse } from '../src/types';
+import { callLLM } from './llm';
+
+export async function generateDiagram(
+  req: DiagramPromptRequest
+): Promise<DiagramResponse> {
+  const description = await callLLM(
+    `Create an SVG diagram for the following request: ${req.prompt}`
+  );
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${
+    req.canvas_width ?? 400
+  }" height="${req.canvas_height ?? 300}"><text x="10" y="20">${description}</text></svg>`;
+  return {
+    diagram_image: svg,
+    diagram_plan: { plan: description, molecule_list: [] },
+    status: 'completed',
+  };
+}

--- a/lib/jobStore.ts
+++ b/lib/jobStore.ts
@@ -1,0 +1,36 @@
+export type JobStatus = 'processing' | 'completed' | 'failed';
+
+export interface JobInfo {
+  id: string;
+  status: JobStatus;
+  progress?: number;
+  result?: unknown;
+  error?: string;
+}
+
+const jobMap = new Map<string, JobInfo>();
+
+export function createJob(initial: Partial<JobInfo> = {}): JobInfo {
+  const id = initial.id ?? Math.random().toString(36).slice(2);
+  const job: JobInfo = {
+    id,
+    status: initial.status ?? 'processing',
+    progress: initial.progress,
+    result: initial.result,
+    error: initial.error,
+  };
+  jobMap.set(id, job);
+  return job;
+}
+
+export function updateJob(id: string, patch: Partial<JobInfo>): JobInfo | undefined {
+  const job = jobMap.get(id);
+  if (!job) return undefined;
+  Object.assign(job, patch);
+  jobMap.set(id, job);
+  return job;
+}
+
+export function getJob(id: string): JobInfo | undefined {
+  return jobMap.get(id);
+}

--- a/lib/llm.ts
+++ b/lib/llm.ts
@@ -1,0 +1,20 @@
+import OpenAI from 'openai';
+
+const apiKey = process.env.OPENAI_API_KEY;
+const openai = apiKey ? new OpenAI({ apiKey }) : undefined;
+
+export async function callLLM(prompt: string): Promise<string> {
+  if (!openai) throw new Error('LLM not configured');
+  const completion = await openai.chat.completions.create({
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: prompt }],
+  });
+  return completion.choices[0]?.message?.content ?? '';
+}
+
+export async function isMolecularPrompt(prompt: string): Promise<boolean> {
+  if (!openai) return true;
+  const question = `Is the following prompt about a molecule or chemistry topic? "${prompt}" Answer yes or no.`;
+  const result = await callLLM(question);
+  return /^yes/i.test(result.trim());
+}

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -1,0 +1,24 @@
+import { ModelInfo } from '../src/types';
+
+export const MODELS: ModelInfo[] = [
+  {
+    name: 'gpt-3.5-turbo',
+    display_name: 'GPT-3.5 Turbo',
+    provider: 'openai',
+    categories: ['general'],
+    context_length: 16000,
+    is_default: true,
+  },
+  {
+    name: 'gpt-4',
+    display_name: 'GPT-4',
+    provider: 'openai',
+    categories: ['general'],
+    context_length: 32000,
+    is_default: false,
+  },
+];
+
+export function listModels(): ModelInfo[] {
+  return MODELS;
+}

--- a/lib/pubchem.ts
+++ b/lib/pubchem.ts
@@ -1,0 +1,45 @@
+import fetch from 'node-fetch';
+
+export interface MoleculeData {
+  pdb_data: string;
+  name: string;
+  cid: number;
+  formula: string;
+  sdf: string;
+}
+
+async function fetchCID(query: string): Promise<number> {
+  const resp = await fetch(
+    `https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/${encodeURIComponent(
+      query
+    )}/cids/JSON`
+  );
+  const data = (await resp.json()) as any;
+  if (!data.IdentifierList?.CID?.length) {
+    throw new Error('Compound not found');
+  }
+  return data.IdentifierList.CID[0];
+}
+
+export async function fetchMoleculeData(query: string): Promise<MoleculeData> {
+  const cid = await fetchCID(query);
+  const sdfResp = await fetch(
+    `https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/${cid}/SDF?record_type=3d`
+  );
+  const sdf = await sdfResp.text();
+  const formulaResp = await fetch(
+    `https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/${cid}/property/MolecularFormula/JSON`
+  );
+  const formulaData = (await formulaResp.json()) as any;
+  return {
+    pdb_data: sdf,
+    name: query,
+    cid,
+    formula: formulaData.PropertyTable?.Properties?.[0]?.MolecularFormula ?? '',
+    sdf,
+  };
+}
+
+export function moleculeHTML(moleculeData: MoleculeData): string {
+  return `<div class="molecule" data-cid="${moleculeData.cid}"></div>`;
+}


### PR DESCRIPTION
## Summary
- implement app router endpoints under `app/api`
- add server-side helpers under `lib`

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'next/server' or its corresponding type declarations)*