### PR TITLE
Fix API base URL

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,19 +2,8 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
-  async rewrites() {
-    // In development, proxy API calls to the live backend to avoid CORS issues.
-    // When you deploy to Vercel / production, these rewrites are ignored
-    // because the frontend and backend will be on different domains with CORS set up.
-    return process.env.NODE_ENV === 'production'
-      ? []
-      : [
-          {
-            source: '/prompt/:path*',
-            destination: 'https://api.moleculens.com/prompt/:path*',
-          },
-        ];
-  },
+  // No dev-time rewrites are needed now that the API has been migrated to
+  // Next.js route handlers under `/api`.
 };
 
 module.exports = nextConfig; 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -50,8 +50,8 @@ interface ComplexPromptResponse {
 // API base URL configuration
 // Priority:
 // 1) Use NEXT_PUBLIC_API_BASE_URL if provided (allows pointing dev build to production backend)
-// 2) Fallback to production URL
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'https://api.moleculens.com';
+// 2) Fallback to using Next.js route handlers under `/api`
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || '/api';
 
 // Only include credentials (cookies) when we are talking to a same-origin localhost backend
 const includeCredentials = API_BASE_URL.startsWith('http://localhost');


### PR DESCRIPTION
## Summary
- default API base URL to use local Next.js `/api` handlers
- remove dev-time proxy in `next.config.js`

## Testing
- `npm run lint`
- `npm run build`
