### PR TITLE
[moleculens] improve molecule fetch error handling

### DIFF
--- a/app/api/prompt/fetch-molecule-data/route.ts
+++ b/app/api/prompt/fetch-molecule-data/route.ts
@@ -10,6 +10,13 @@ export async function POST(req: NextRequest) {
     const data = await fetchMoleculeData(query);
     return NextResponse.json(data);
   } catch (err: any) {
-    return NextResponse.json({ error: err.message }, { status: 500 });
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    if (message === 'Compound not found') {
+      return NextResponse.json({ error: message }, { status: 404 });
+    }
+    if (message.startsWith('Network error')) {
+      return NextResponse.json({ error: message }, { status: 503 });
+    }
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -105,13 +105,18 @@ export const fetchMoleculeData = async (
       credentials: includeCredentials ? 'include' : 'same-origin',
       body: JSON.stringify({ query }),
     });
+    let result: any = {};
+    try {
+      result = await response.json();
+    } catch {
+      // ignore parse errors
+    }
 
     if (!response.ok) {
-      throw new Error(`Failed to fetch molecule data: ${response.status} ${response.statusText}`);
+      const message = result?.error ? result.error : `${response.status} ${response.statusText}`;
+      throw new Error(`Failed to fetch molecule data: ${message}`);
     }
-    const result = await response.json();
 
-    // If there's an error message, throw
     if (result.detail) {
       throw new Error(result.detail);
     }


### PR DESCRIPTION
## Summary
- add detailed fetch error checks in `lib/pubchem.ts`
- surface specific HTTP status codes from `/fetch-molecule-data` route
- propagate backend error message in frontend `fetchMoleculeData`

## Testing
- `npm run format`
- `npm run lint`
