### PR TITLE
[moleculens] refactor prompt classification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,13 +3,16 @@
 This repository is a Next.js TypeScript project. The backend is being migrated from Python FastAPI to Next.js route handlers.
 
 ## Agent Setup
+
 -`scripts/setup-agent.sh` is already run before the container is built but just keep in mind that script was previously executed in the current environment.
 
 ## Development Workflow
+
 1. Format and lint the code with `npm run format` and `npm run lint`.
 2. Build the project with `npm run build` if needed.
 
 ### Pull Request Guidelines
+
 - Title format: `[moleculens] <Title>`
 - Keep changes small and focused.
 - Ensure `npm run lint` passes before opening a PR.
@@ -19,9 +22,11 @@ This repository is a Next.js TypeScript project. The backend is being migrated f
 # Next.js Backend Migration Plan
 
 ## Goal
+
 Consolidate the existing Python FastAPI backend into a TypeScript based backend using Next.js (App Router). All APIs that the frontend currently depends on should be reimplemented as Next.js route handlers. Logic shared across routes will live under a `/lib` directory. Only the endpoints referenced from `api.ts` need to be ported initially.
 
 ## Target Folder Layout
+
 ```
 / (project root)
 ├─ app/
@@ -44,7 +49,9 @@ Consolidate the existing Python FastAPI backend into a TypeScript based backend 
 ```
 
 ### app/api
+
 Next.js route handlers inside `app/api` expose HTTP endpoints. Each file should define the HTTP method handlers (e.g. `GET`, `POST`) needed by the frontend.
+
 - **process/[jobId]/route.ts** – `GET` handler used by `pollJobStatus`. Reads job status from `jobStore`.
 - **fetch-molecule-data/route.ts** – `POST` handler. Uses `pubchem.ts` helper to retrieve minimal molecule data.
 - **generate-molecule-html/route.ts** – `POST` handler. Accepts cached molecule data and returns HTML generated through the helpers in `pubchem.ts`.
@@ -53,14 +60,17 @@ Next.js route handlers inside `app/api` expose HTTP endpoints. Each file should 
 - **generate-molecule-diagram/route.ts** – `POST` handler for the diagram feature. Uses `diagram.ts` utilities and `llm.ts` to produce an SVG string.
 
 ### lib utilities
+
 Reusable logic extracted from the Python code will be translated to TypeScript modules under `lib/`.
+
 - **jobStore.ts** – Minimal in‑memory store for background job information (`status`, `progress`, `result`). Exposes helper functions `createJob`, `updateJob`, `getJob`.
 - **pubchem.ts** – Functions to interact with PubChem APIs and to build molecule HTML. Ports the logic from `PubChemAgent`.
-- **llm.ts** – Wrapper around whatever LLM provider is used. Contains validation helpers like `isMolecularPrompt()` plus generic request function `callLLM()`.
+- **llm.ts** – Wrapper around the configured LLM. Provides utilities such as `classifyPrompt()` and the generic request function `callLLM()`.
 - **models.ts** – Defines the TypeScript interface for `ModelInfo` and a registry of available models. Mirrors the Python `ModelRegistry`.
 - **diagram.ts** – Utilities to generate 2‑D diagrams: planning with the LLM and rendering SVG using 2‑D coordinates. Should export `generateDiagram()` used by the route handler.
 
 ## Implementation Notes
+
 1. **Keep Types Strict** – Create TypeScript interfaces mirroring the request/response models currently returned by the Python routes so the frontend API layer stays unchanged.
 2. **Background Jobs** – For the `process` endpoint the heavy pipeline work should run in a background task (e.g. using `queueMicrotask` or a lightweight job queue). Store intermediate results in `jobStore`.
 3. **Environment Variables** – Env variables are already exposed in the container. Use `process.env` to access them in the route handlers. For example, `process.env.PUBCHEM_API_KEY`.

--- a/app/api/prompt/generate-from-pubchem/route.ts
+++ b/app/api/prompt/generate-from-pubchem/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { fetchMoleculeData, moleculeHTML } from '../../../../lib/pubchem';
-import { isMolecularPrompt, interpretQueryToMoleculeName } from '../../../../lib/llm';
+import { classifyPrompt, interpretQueryToMoleculeName } from '../../../../lib/llm';
 
 export async function POST(req: NextRequest) {
   const body = await req.json();
@@ -8,12 +8,35 @@ export async function POST(req: NextRequest) {
   if (!query) {
     return NextResponse.json({ error: 'Missing prompt', status: 'failed' }, { status: 400 });
   }
-  const ok = await isMolecularPrompt(query);
-  if (!ok) {
-    return NextResponse.json({ status: 'failed', job_id: 'rejected', error: 'Prompt not about molecules' });
-  }
+
   try {
-    const moleculeQuery = await interpretQueryToMoleculeName(query);
+    const classification = await classifyPrompt(query);
+    if (classification.type === 'unknown') {
+      return NextResponse.json({
+        status: 'failed',
+        job_id: 'rejected',
+        error: 'Prompt not about molecules',
+      });
+    }
+
+    if (classification.type === 'macromolecule') {
+      const response = await fetch('https://meshmo.com/prompt/generate-from-rcsb/', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ prompt: classification.name ?? query }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`RCSB API responded with status: ${response.status}`);
+      }
+
+      const data = await response.json();
+      return NextResponse.json(data);
+    }
+
+    const moleculeQuery = classification.name ?? (await interpretQueryToMoleculeName(query));
     const data = await fetchMoleculeData(moleculeQuery);
     const html = moleculeHTML(data);
     return NextResponse.json({ sdf: data.sdf, result_html: html, title: data.name });

--- a/lib/pubchem.ts
+++ b/lib/pubchem.ts
@@ -22,7 +22,7 @@ const MOLECULENS_API = 'https://api.moleculens.com/prompt';
 const COMMON_NAME_MAPPINGS: Record<string, string> = {
   bullvalene: 'tricyclo[3.3.2.0²,⁸]deca-3,6,9-triene',
   'crown ether': '18-crown-6',
-  'crown ethers': '18-crown-6'
+  'crown ethers': '18-crown-6',
   // …
 };
 
@@ -48,7 +48,7 @@ function candidateStrings(input: string): string[] {
   let s = raw.replace(/["'""]/g, '');
 
   // 2. strip possessive 's  (ferrocene's -> ferrocene)
-  s = s.replace(/\b([A-Za-z0-9\-]+)'s\b/gi, '$1');
+  s = s.replace(/\b([A-Za-z0-9-]+)'s\b/gi, '$1');
   if (s !== raw) set.add(s);
 
   // 3. remove simple punctuation , . ; : ? ! ( )
@@ -56,11 +56,14 @@ function candidateStrings(input: string): string[] {
   if (punctFree !== s) set.add(punctFree);
 
   // 4. single‑word tokens (≥3 chars) and bigrams
-  const words = punctFree.split(/\s+/)
-    .map(w => w.replace(/[^A-Za-z0-9+\-\[\]]/g, ''))
+  const words = punctFree
+    .split(/\s+/)
+    .map(w => w.replace(/[^A-Za-z0-9+\-[\]]/g, ''))
     .filter(Boolean);
 
-  words.forEach(w => { if (w.length >= 3) set.add(w); });
+  words.forEach(w => {
+    if (w.length >= 3) set.add(w);
+  });
 
   for (let i = 0; i < words.length - 1; i++) {
     const bigram = `${words[i]} ${words[i + 1]}`.trim();
@@ -104,29 +107,29 @@ export async function fetchMoleculeData(query: string): Promise<MoleculeData> {
   console.log(`[PubChemService] Resolved CID: ${cid} for query: "${query}"`);
 
   // 2. Get SDF data
-  const sdfResp = await fetch(
-    `${PUBCHEM}/compound/cid/${cid}/SDF`
-  );
+  const sdfResp = await fetch(`${PUBCHEM}/compound/cid/${cid}/SDF`);
   if (!sdfResp.ok) {
     const errorText = await sdfResp.text();
     console.error(`[PubChemService] PubChem SDF request failed: ${sdfResp.status} - ${errorText}`);
     throw new Error(`PubChem SDF request failed: ${sdfResp.status} - ${errorText}`);
   }
   const sdf = await sdfResp.text();
-  console.log(`[PubChemService] Successfully fetched SDF data (length: ${sdf.length}) for CID: ${cid}`);
+  console.log(
+    `[PubChemService] Successfully fetched SDF data (length: ${sdf.length}) for CID: ${cid}`
+  );
 
   // 3. Get formula
-  const formulaResp = await fetch(
-    `${PUBCHEM}/compound/cid/${cid}/property/MolecularFormula/JSON`
-  );
+  const formulaResp = await fetch(`${PUBCHEM}/compound/cid/${cid}/property/MolecularFormula/JSON`);
   if (!formulaResp.ok) {
     const errorText = await formulaResp.text();
-    console.error(`[PubChemService] PubChem formula request failed: ${formulaResp.status} - ${errorText}`);
+    console.error(
+      `[PubChemService] PubChem formula request failed: ${formulaResp.status} - ${errorText}`
+    );
     // Not throwing here, as formula is non-critical, but will log and return empty
   }
   let formula = '';
   if (formulaResp.ok) {
-    const formulaData = await formulaResp.json() as any; // Type assertion for safety
+    const formulaData = (await formulaResp.json()) as any; // Type assertion for safety
     formula = formulaData.PropertyTable?.Properties?.[0]?.MolecularFormula ?? '';
     console.log(`[PubChemService] Successfully fetched formula: ${formula} for CID: ${cid}`);
   }
@@ -136,9 +139,14 @@ export async function fetchMoleculeData(query: string): Promise<MoleculeData> {
   let pdb_data = '';
   try {
     pdb_data = await convertSDFToPDB(sdf);
-    console.log(`[PubChemService] Successfully converted SDF to PDB (length: ${pdb_data.length}) for CID: ${cid}`);
+    console.log(
+      `[PubChemService] Successfully converted SDF to PDB (length: ${pdb_data.length}) for CID: ${cid}`
+    );
   } catch (conversionError) {
-    console.error(`[PubChemService] SDF to PDB conversion failed for CID: ${cid}:`, conversionError);
+    console.error(
+      `[PubChemService] SDF to PDB conversion failed for CID: ${cid}:`,
+      conversionError
+    );
     // If conversion fails, we might still want to return other data, but PDB will be empty
   }
 
@@ -151,40 +159,41 @@ export async function fetchMoleculeData(query: string): Promise<MoleculeData> {
   };
 }
 
+export function moleculeHTML(moleculeData: MoleculeData): string {
+  return `<div class="molecule" data-cid="${moleculeData.cid}"></div>`;
+}
+
 /* ----------  helpers  ---------- */
 
 async function cidByExact(term: string): Promise<number | null> {
-  const r = await fetch(
-    `${PUBCHEM}/compound/name/${encodeURIComponent(term)}/cids/JSON`
-  );
+  const r = await fetch(`${PUBCHEM}/compound/name/${encodeURIComponent(term)}/cids/JSON`);
   if (!r.ok) return null;
-  const data = await r.json() as any;
+  const data = (await r.json()) as any;
   return data?.IdentifierList?.CID?.[0] ?? null;
 }
 
 // B. autocomplete → reuse A.
 async function cidByAutocomplete(term: string): Promise<number | null> {
-  const r = await fetch(
-    `${PUBCHEM}/autocomplete/${encodeURIComponent(term)}/JSON?limit=20`
-  );                       
+  const r = await fetch(`${PUBCHEM}/autocomplete/${encodeURIComponent(term)}/JSON?limit=20`);
   if (!r.ok) return null;
-  const best = (await r.json() as any)?.dictionary_terms?.compound?.[0];
+  const best = ((await r.json()) as any)?.dictionary_terms?.compound?.[0];
   return best ? cidByExact(best) : null;
 }
 
 // C. Entrez class search
 async function cidByClassSearch(term: string): Promise<number | null> {
-  const xml = await fetch(
-    `${PUBCHEM}/compound/name/${encodeURIComponent(term)}/cids/XML`
-  ).then(res => res.text());          
+  const xml = await fetch(`${PUBCHEM}/compound/name/${encodeURIComponent(term)}/cids/XML`).then(
+    res => res.text()
+  );
   const cids = [...xml.matchAll(/<Id>(\d+)<\/Id>/g)].map(m => m[1]);
   if (!cids.length) return null;
 
   const prop = await fetch(
     `${PUBCHEM}/compound/cid/${cids.join(',')}/property/SubstanceCount/JSON`
   ).then(res => res.json() as any);
-  const best = prop.PropertyTable?.Properties
-      ?.sort((a: any, b: any) => b.SubstanceCount - a.SubstanceCount)[0];
+  const best = prop.PropertyTable?.Properties?.sort(
+    (a: any, b: any) => b.SubstanceCount - a.SubstanceCount
+  )[0];
 
   return best?.CID ?? null;
 }
@@ -198,7 +207,7 @@ async function convertSDFToPDB(sdfData: string): Promise<string> {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ sdf: sdfData })
+      body: JSON.stringify({ sdf: sdfData }),
     });
 
     if (!response.ok) {
@@ -206,7 +215,7 @@ async function convertSDFToPDB(sdfData: string): Promise<string> {
       throw new Error(`SDF to PDB conversion failed: ${response.status} - ${errorText}`);
     }
 
-    const data = await response.json() as SDFToPDBResponse;
+    const data = (await response.json()) as SDFToPDBResponse;
     console.log('[PubChemService] Successfully converted SDF to PDB using Moleculens API');
     return data.pdb_data;
   } catch (error) {


### PR DESCRIPTION
## Summary
- enhance docs to mention `classifyPrompt`
- classify user queries with a new `classifyPrompt` helper
- route `generate-from-pubchem` can return data from PubChem or RCSB
- restore `moleculeHTML` helper in `pubchem.ts`

## Testing
- `npm run lint`
- `npm run build`
