### PR TITLE
Fix overlapping molecule caption

### DIFF
--- a/app/components/panels/MoleculeViewer.tsx
+++ b/app/components/panels/MoleculeViewer.tsx
@@ -7,7 +7,6 @@ import { PDBLoader } from 'three/examples/jsm/loaders/PDBLoader';
 // @ts-expect-error - Three.js examples module not properly typed but works correctly
 import { CSS2DRenderer, CSS2DObject } from 'three/examples/jsm/renderers/CSS2DRenderer';
 import { LoadingFacts } from './LoadingFacts';
-import ScrollingText from './ScrollingText';
 
 // Constants for animation
 const ROTATION_SPEED = 0.1; // Rotations per second
@@ -27,6 +26,7 @@ interface MoleculeViewerProps {
 
 export default function MoleculeViewer({ isLoading = false, pdbData, title, showAnnotations = true }: MoleculeViewerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const captionRef = useRef<HTMLDivElement | null>(null);
   const labelContainerRef = useRef<HTMLDivElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -131,6 +131,7 @@ export default function MoleculeViewer({ isLoading = false, pdbData, title, show
         containerRef.current.clientHeight
       );
       containerRef.current.appendChild(renderer.domElement);
+
 
       // CSS2D renderer
       if (showAnnotations) {
@@ -548,6 +549,29 @@ export default function MoleculeViewer({ isLoading = false, pdbData, title, show
     };
   }, []);
 
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const container = containerRef.current;
+
+    // hide/remove fallback <div class="molecule"> rendered by server
+    container
+      .querySelectorAll('.molecule')
+      .forEach((el) => ((el as HTMLElement).style.display = 'none'));
+
+    // ensure single caption overlay
+    if (!captionRef.current) {
+      const c = document.createElement('div');
+      c.className = 'molecule-title';
+      container.appendChild(c);
+      captionRef.current = c;
+    }
+
+    // update text on every title change
+    if (captionRef.current) {
+      captionRef.current.textContent = title;
+    }
+  }, [title]);
+
 
   // The outer wrapper helps position the label absolutely
   return (
@@ -568,18 +592,6 @@ export default function MoleculeViewer({ isLoading = false, pdbData, title, show
             ref={labelContainerRef} 
             className="absolute inset-0 pointer-events-none" 
           />
-          {/* Molecule label - Updated to use ScrollingText */}
-          <div
-            className="absolute bottom-5 left-1/2 transform -translate-x-1/2 
-                       text-white px-5 py-2.5 rounded-lg z-20 
-                       pointer-events-none text-center max-w-[80%] 
-                       text-base md:text-lg"
-            // Removed truncate, overflow will be handled by ScrollingText
-            // Ensure this div provides a clear width for ScrollingText to measure against.
-            // Text-align might need to be left if ScrollingText doesn't center its content naturally.
-          >
-            <ScrollingText text={title} />
-          </div>
           {/* Control buttons */}
           <div className="absolute top-4 right-4 z-20 flex space-x-2">
             {/* Pause/Play button */}

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -114,6 +114,19 @@
   .panel {
     @apply bg-white rounded-lg shadow-lg p-4;
   }
+
+  .molecule-title {
+    position: absolute;
+    bottom: 8px;
+    left: 8px;
+    max-width: 90%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    pointer-events: none;
+    font-weight: 600;
+    color: #fff;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- hide fallback DOM caption after WebGL viewer initializes
- ensure single caption overlay with a new DOM element
- style `.molecule-title` for overflow

## Testing
- `npx eslint app/components/panels/MoleculeViewer.tsx`
