### PR TITLE
Add molecule info panel

### DIFF
--- a/app/api/prompt/fetch-molecule-data/route.ts
+++ b/app/api/prompt/fetch-molecule-data/route.ts
@@ -28,6 +28,7 @@ export async function POST(req: NextRequest) {
       name: data.name,
       cid: data.cid,
       formula: data.formula,
+      info: data.info,
     });
   } catch (err: any) {
     return NextResponse.json({ status: 'failed', error: err.message }, { status: 500 });

--- a/app/components/panels/InputPanel.tsx
+++ b/app/components/panels/InputPanel.tsx
@@ -32,6 +32,7 @@ interface InputPanelProps {
   usePubChem?: boolean;
   currentHtml?: string;
   currentTitle?: string;
+  onInfoUpdate?: (info: any) => void;
 }
 
 // Update the JobStatusResponse interface to include legacy fields
@@ -68,6 +69,7 @@ export const InputPanel: React.FC<InputPanelProps> = ({
   usePubChem,
   currentHtml: initialHtml,
   currentTitle: initialTitle,
+  onInfoUpdate,
 }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [currentScript, setCurrentScript] = useState<string | null>(null);
@@ -645,11 +647,13 @@ export const InputPanel: React.FC<InputPanelProps> = ({
         const name = response.name;
         const cid = response.cid;
         const formula = response.formula;
+        const info = response.info;
 
         setCurrentScript(pdbData);
         setTitle(name);
         //setCurrentHtml(html);
         onVisualizationUpdate(pdbData, undefined, name ?? undefined);
+        if (onInfoUpdate) onInfoUpdate(info);
         onPromptSubmit(currentPrompt, { pdb_data: pdbData, html: '', title: name });
         setIsLoading(false);
         onLoadingChange(false);

--- a/app/components/panels/MoleculeViewer.tsx
+++ b/app/components/panels/MoleculeViewer.tsx
@@ -23,15 +23,17 @@ interface MoleculeViewerProps {
    * disable this to improve performance.  Defaults to true.
    */
   showAnnotations?: boolean;
+  moleculeInfo?: any | null;
 }
 
-export default function MoleculeViewer({ isLoading = false, pdbData, title, showAnnotations = true }: MoleculeViewerProps) {
+export default function MoleculeViewer({ isLoading = false, pdbData, title, showAnnotations = true, moleculeInfo }: MoleculeViewerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const captionRef = useRef<HTMLDivElement | null>(null);
   const labelContainerRef = useRef<HTMLDivElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
+  const [isInfoOpen, setIsInfoOpen] = useState(false);
   const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
   const labelRendererRef = useRef<CSS2DRenderer | null>(null);
   const rotationRef = useRef<number>(0);
@@ -541,6 +543,10 @@ export default function MoleculeViewer({ isLoading = false, pdbData, title, show
     setIsPaused(!isPaused);
   };
 
+  const toggleInfo = () => {
+    setIsInfoOpen(!isInfoOpen);
+  };
+
   useEffect(() => {
     const handleFullscreenChange = () => {
       setIsFullscreen(!!document.fullscreenElement);
@@ -622,6 +628,16 @@ export default function MoleculeViewer({ isLoading = false, pdbData, title, show
                 </svg>
               )}
             </button>
+            {/* Info button */}
+            <button
+              onClick={toggleInfo}
+              className="p-2 rounded-lg text-white hover:text-gray-300 transition-colors duration-200"
+              title={isInfoOpen ? 'Hide Info' : 'Show Info'}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-9-3a1 1 0 112 0 1 1 0 01-2 0zm2 8a1 1 0 11-2 0v-4a1 1 0 112 0v4z" clipRule="evenodd" />
+              </svg>
+            </button>
             {/* Fullscreen button */}
             <button
               onClick={toggleFullscreen}
@@ -640,6 +656,27 @@ export default function MoleculeViewer({ isLoading = false, pdbData, title, show
               )}
             </button>
           </div>
+          {moleculeInfo && (
+            <div
+              className={`absolute left-0 right-0 bottom-0 bg-gray-800 bg-opacity-90 text-white text-xs p-3 transition-transform duration-300 ${isInfoOpen ? 'translate-y-0' : 'translate-y-full'}`}
+            >
+              {moleculeInfo.formula && (
+                <div className="mb-1">Formula: {moleculeInfo.formula}</div>
+              )}
+              {moleculeInfo.formula_weight && (
+                <div className="mb-1">MW: {moleculeInfo.formula_weight}</div>
+              )}
+              {moleculeInfo.canonical_smiles && (
+                <div className="mb-1 break-all">SMILES: {moleculeInfo.canonical_smiles}</div>
+              )}
+              {moleculeInfo.inchi && (
+                <div className="mb-1 break-all">InChI: {moleculeInfo.inchi}</div>
+              )}
+              {moleculeInfo.synonyms && moleculeInfo.synonyms.length > 0 && (
+                <div className="mb-1">Synonyms: {moleculeInfo.synonyms.slice(0,3).join(', ')}</div>
+              )}
+            </div>
+          )}
         </>
       )}
     </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -41,6 +41,7 @@ END`;
   const [isInteractive, setIsInteractive] = useState(false);
   const [history, setHistory] = useState<HistoryEntry[]>([]);
   const [isTimeMachineOpen, setIsTimeMachineOpen] = useState(false);
+  const [moleculeInfo, setMoleculeInfo] = useState<any | null>(null);
 
   const handleVisualizationUpdate = (pdb: string, htmlContent?: string, vizTitle?: string) => {
     setPdbData(pdb);
@@ -90,27 +91,29 @@ END`;
         <LayoutWrapper useConstraints={true}>
           <div className="panels-container">
             <div className="input-panel-container">
-              <InputPanel
-                onVisualizationUpdate={handleVisualizationUpdate}
-                onLoadingChange={setIsLoading}
-                currentPrompt={prompt}
-                onPromptChange={setPrompt}
-                onPromptSubmit={handlePromptSubmit}
-                model={model}
-                isInteractive={isInteractive}
-                usePubChem={true}
-                currentHtml={html ?? undefined}
-                currentTitle={title ?? undefined}
-              />
-            </div>
+            <InputPanel
+              onVisualizationUpdate={handleVisualizationUpdate}
+              onLoadingChange={setIsLoading}
+              currentPrompt={prompt}
+              onPromptChange={setPrompt}
+              onPromptSubmit={handlePromptSubmit}
+              model={model}
+              isInteractive={isInteractive}
+              usePubChem={true}
+              currentHtml={html ?? undefined}
+              currentTitle={title ?? undefined}
+              onInfoUpdate={setMoleculeInfo}
+            />
+          </div>
 
-            <div className="molecule-viewer-container">
-              <MoleculeViewer
-                isLoading={isLoading}
-                pdbData={pdbData!}
-                title={title!}
-              />
-            </div>
+          <div className="molecule-viewer-container">
+            <MoleculeViewer
+              isLoading={isLoading}
+              pdbData={pdbData!}
+              title={title!}
+              moleculeInfo={moleculeInfo}
+            />
+          </div>
           </div>
         </LayoutWrapper>
       </main>

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -99,6 +99,7 @@ export const fetchMoleculeData = async (
   name: string;
   cid: number;
   formula: string;
+  info: any;
   sdf: string;
 }> => {
   const endpoint = `${API_BASE_URL}/prompt/fetch-molecule-data/`;

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -59,6 +59,17 @@ export interface ModelInfo {
   is_default: boolean;
 }
 
+export interface MoleculeInfo {
+  formula?: string;
+  formula_weight?: number;
+  canonical_smiles?: string;
+  isomeric_smiles?: string;
+  inchi?: string;
+  inchikey?: string;
+  formal_charge?: number;
+  synonyms?: string[];
+}
+
 export interface MoleculePlacement {
   molecule: string;
   x: number;


### PR DESCRIPTION
## Summary
- extend `MoleculeData` with new `MoleculeInfo` metadata
- fetch extra properties from PubChem
- expose molecule info through API and client helpers
- surface extra data in InputPanel and store it on the page
- show an info button in MoleculeViewer that toggles a details panel

## Testing
- `npm run lint`