### PR TITLE
Fix missing info field and adjust scrolling title

### DIFF
--- a/app/components/panels/ScrollingText.tsx
+++ b/app/components/panels/ScrollingText.tsx
@@ -11,6 +11,7 @@ const ScrollingText: React.FC<ScrollingTextProps> = ({ text, className }) => {
   const textRef = useRef<HTMLSpanElement>(null);
   const [isOverflowing, setIsOverflowing] = useState(false);
   const [animationDuration, setAnimationDuration] = useState('20s');
+  const [duplicateOffset, setDuplicateOffset] = useState(0);
 
   useEffect(() => {
     const checkOverflowAndSetDuration = () => {
@@ -21,6 +22,7 @@ const ScrollingText: React.FC<ScrollingTextProps> = ({ text, className }) => {
         setIsOverflowing(newIsOverflowing);
 
         if (newIsOverflowing) {
+          setDuplicateOffset(textWidth);
           // Adjust the divisor (e.g., 40) to control speed. Lower = faster.
           const duration = Math.max(5, textWidth / 40); // Min duration 5s
           setAnimationDuration(`${duration}s`);
@@ -50,7 +52,7 @@ const ScrollingText: React.FC<ScrollingTextProps> = ({ text, className }) => {
         <span
           aria-hidden="true"
           className={`${styles.span} ${styles.animate} ${styles.duplicate}`}
-          style={{ animationDuration }}
+          style={{ animationDuration, left: `${duplicateOffset}px` }}
         >
           {text}
         </span>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './styles/globals.css';
 import './styles/MoleculeViewer.css';
-import './styles/ScrollingText.css';
 import './styles/audio-waveform.css';
 
 const inter = Inter({ subsets: ['latin'] });

--- a/app/lib/pubchem.ts
+++ b/app/lib/pubchem.ts
@@ -222,6 +222,7 @@ export async function fetchMoleculeData(query: string, type: 'small molecule' | 
       name: response.title || query,
       cid: 0,
       formula: '',
+      info: {},
     };
   }
   // 1. Get CID


### PR DESCRIPTION
## Summary
- include `info` when resolving macromolecule data
- tweak `ScrollingText` so duplicate span starts after measured width
- remove unused global scrolling text stylesheet

## Testing
- `npm run lint`
